### PR TITLE
chore(bom-upload): Always set current project as active

### DIFF
--- a/src/test/java/com/mediamarktsaturn/technolinator/sbom/DependencyTrackClientTest.java
+++ b/src/test/java/com/mediamarktsaturn/technolinator/sbom/DependencyTrackClientTest.java
@@ -166,7 +166,7 @@ class DependencyTrackClientTest {
         assertThat(patchedProjects[2]).satisfies(described -> {
             assertThat(described.getPath()).hasToString("/api/v1/project/uuid-3");
             var json = new JsonObject(described.getBodyAsString());
-            assertThat(json.getBoolean("active")).isNull();
+            assertThat(json.getBoolean("active")).isTrue();
             assertThat(json.getString("description")).hasToString(description);
             assertThat(json.getJsonArray("tags")).containsExactlyInAnyOrder(
                 JsonObject.of("name", "thisIsGreat"),


### PR DESCRIPTION
Handling of an edge case that ensures the current version of a project is always _active_.

If you switched your default branch forth and back you could end up in a situation with your current version being inactive.

E.g. active branch from _dev_ (step 1) to _master_ (step 2) and back again to _dev_ (step 3).

Formally step 2 deactivated _dev_ (`active: false`) and _master_ had the property `active` not set explicitly which is handled as _active_ by dtrack. If you now switched back to version `dev` as step 3 the property `active: false` still remained. This results in all versions having the property `active: false`.

This patch now always sets the property `active: true` on the current submitted version.
 