### PR TITLE
chore(github): add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,51 @@
+name: Bug Report
+description: File a bug report
+title: "[Bug]: "
+labels: ["bug"]
+assignees:
+  - heubeck
+  - johannesmarx
+  - beiertu-mms
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ### Thank you for taking your time to fill out this bug report!
+        Please also search the [issues](https://github.com/MediaMarktSaturn/technolinator/issues) first before submitting a new one.
+
+  - type: textarea
+    id: expected-behavior
+    attributes:
+      label: Expected Behavior
+      description: |
+        Tell us what should happen.
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual-behavior
+    attributes:
+      label: Actual Behavior
+      description: |
+        Tell us what happens instead of the expected behavior.
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps-to-reproduce
+    attributes:
+      label: Steps to Reproduce
+      description: |
+        Please provide a step by step instruction to reproduce this bug if applicable.
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional-info
+    attributes:
+      label: Additional Information
+      description: |
+        Include here any additional information (version used, environment, etc.), which you think are relevant to this bug.
+    validations:
+      required: false
+

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,2 @@
+---
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,42 @@
+name: Feature Request
+description: Request a new feature
+title: "[FEAT]: "
+labels: ["enhancement"]
+assignees:
+  - heubeck
+  - johannesmarx
+  - beiertu-mms
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ### Thank you for taking your time to fill out this form!
+        Please also search the [issues](https://github.com/MediaMarktSaturn/technolinator/issues) first before submitting a new one.
+
+  - type: textarea
+    id: expected-behavior
+    attributes:
+      label: Expected Behavior
+      description: |
+        Tell us what should be improved/added/changed/removed.
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual-behavior
+    attributes:
+      label: Actual Behavior
+      description: |
+        Tell us the current behavior.
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional-info
+    attributes:
+      label: Additional Information
+      description: |
+        Include here any additional information, which you think are relevant to this request.
+    validations:
+      required: false
+

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -14,20 +14,11 @@ body:
         Please also search the [issues](https://github.com/MediaMarktSaturn/technolinator/issues) first before submitting a new one.
 
   - type: textarea
-    id: expected-behavior
+    id: request-description
     attributes:
-      label: Expected Behavior
+      label: Request Description
       description: |
-        Tell us what should be improved/added/changed/removed.
-    validations:
-      required: true
-
-  - type: textarea
-    id: actual-behavior
-    attributes:
-      label: Actual Behavior
-      description: |
-        Tell us the current behavior.
+        Tell us what should be improved/added/changed/removed and why you think it's necessary.
     validations:
       required: true
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
             - 'README.md'
             - '.github/dependabot.yml'
             - '.github/technolinator.yml'
+            - '.github/ISSUE_TEMPLATE/**'
 env:
     CDXGEN_VERSION: '9.7.3'
     CDXGEN_PLUGINS_VERSION: '1.4.0'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,6 @@ on:
             - 'README.md'
             - '.github/dependabot.yml'
             - '.github/technolinator.yml'
-            - '.github/ISSUE_TEMPLATE/**'
 env:
     CDXGEN_VERSION: '9.7.3'
     CDXGEN_PLUGINS_VERSION: '1.4.0'


### PR DESCRIPTION
Add templates for bug report and feature request, to guide users with
submitting new issues.

See also:
- https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests
