### PR TITLE
ci(actions): adjust release creation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,9 @@ jobs:
                   npm install -g @cyclonedx/cdxgen@${CDXGEN_VERSION}
                   npm install -g @cyclonedx/cdxgen-plugins-bin@${CDXGEN_PLUGINS_VERSION}
 
+                  # changelog-conventionalcommits for GitHub release creation
+                  npm install -D conventional-changelog-conventionalcommits
+
                   mkdir _bin
                   echo $(pwd)/_bin >> $GITHUB_PATH
 

--- a/.releaserc
+++ b/.releaserc
@@ -3,8 +3,51 @@
     "main"
   ],
   "plugins": [
-    "@semantic-release/commit-analyzer",
-    "@semantic-release/github",
-    "@semantic-release/release-notes-generator"
+    [
+      "@semantic-release/commit-analyzer",
+      {
+        "releaseRules": [
+          { "type": "feat", "release": "minor" },
+          { "type": "perf", "release": "minor" },
+          { "type": "build", "release": "patch" },
+          { "type": "fix", "release": "patch" },
+          { "type": "refactor", "release": "patch" },
+          { "type": "revert", "release": "patch" },
+          { "type": "chore", "release": false },
+          { "type": "ci", "release": false },
+          { "type": "docs", "release": false },
+          { "type": "style", "release": false },
+          { "type": "test", "release": false }
+        ]
+      }
+    ],
+    [
+      "@semantic-release/github",
+      {
+        "successComment": false,
+        "failTitle": false
+      }
+    ],
+    [
+      "@semantic-release/release-notes-generator",
+      {
+        "preset": "conventionalcommits",
+        "presetConfig": {
+          "types": [
+            { "type": "feat", "section": ":sparkles: Features", "hidden": false },
+            { "type": "perf", "section": ":zap: Performance Enhancement", "hidden": false },
+            { "type": "build", "section": ":building_construction: Build", "hidden": false },
+            { "type": "fix", "section": ":bug: Fixes", "hidden": false },
+            { "type": "refactor", "section": ":recycle: Refactoring", "hidden": false },
+            { "type": "revert", "section": ":rewind: Revert", "hidden": false },
+            { "type": "chore", "section": ":arrow_up: Updates", "hidden": false },
+            { "type": "ci", "section": ":repeat: Continuous Integration", "hidden": false },
+            { "type": "docs", "section": ":memo: Documentation", "hidden": false },
+            { "type": "style", "section": ":art: Styling", "hidden": false },
+            { "type": "test", "section": ":white_check_mark: Testing", "hidden": false }
+          ]
+        }
+      }
+    ]
   ]
 }


### PR DESCRIPTION
Define all possible commit types and their corresponding releases.
And add the conventional commits preset in release-note-generator
plugin, so that a more useful release note can be generated.

See also:
- https://github.com/semantic-release/commit-analyzer#rules-definition
- https://github.com/semantic-release/release-notes-generator/issues/153#issuecomment-555152563
