### PR TITLE
fix(actions): fix CI on release creation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,9 @@ jobs:
                   java-version: '${{ env.java_version }}'
                   distribution: 'temurin'
 
+            - name: Install dependencies for semantic-release-action
+              run: npm install -D conventional-changelog-conventionalcommits
+
             - name: Getting next release version
               id: semantic
               uses: cycjimmy/semantic-release-action@v4
@@ -43,9 +46,6 @@ jobs:
                   # cdxgen
                   npm install -g @cyclonedx/cdxgen@${CDXGEN_VERSION}
                   npm install -g @cyclonedx/cdxgen-plugins-bin@${CDXGEN_PLUGINS_VERSION}
-
-                  # changelog-conventionalcommits for GitHub release creation
-                  npm install -D conventional-changelog-conventionalcommits
 
                   mkdir _bin
                   echo $(pwd)/_bin >> $GITHUB_PATH


### PR DESCRIPTION
Required dependencies need to be installed before `semantic-release` can be invoked.
Related to https://github.com/MediaMarktSaturn/technolinator/pull/189.