### PR TITLE
ci(actions): skip ci on main for dependabot merges

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,9 @@ jobs:
     ci:
         name: Application Build
         runs-on: ubuntu-latest
+        if: |
+            github.actor != 'dependabot[bot]' ||
+            (github.actor == 'dependabot[bot]' &&  github.ref != 'refs/heads/main')
         steps:
 
             - name: Checkout Code


### PR DESCRIPTION
Build on main, triggered by dependabot merges (by commented on the
pull request with for example `@dependabot merge`), is failing because
dependabot actor does not have sufficient permissions.
