### PR TITLE
ci(actions): add concurrency to ci workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
             - 'README.md'
             - '.github/dependabot.yml'
             - '.github/technolinator.yml'
+concurrency:
+    group: ${{ github.ref }}-${{ github.workflow }}
+    cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 env:
     CDXGEN_VERSION: '9.9.0'
     CDXGEN_PLUGINS_VERSION: '1.4.0'


### PR DESCRIPTION
Cancel any concurrent builds for any non-main branches to not wasted
build minutes.

See also:
- https://docs.github.com/en/actions/using-jobs/using-concurrency
