### PR TITLE
ci(actions): add composite action install-requirements

### DIFF
--- a/.github/actions/install-requirements/action.yaml
+++ b/.github/actions/install-requirements/action.yaml
@@ -1,26 +1,33 @@
 ---
 name: 'install-requirements'
-description: ''
+description: 'Install required dependencies for the build of this application'
 inputs:
   grype_version:
-    description: ''
+    description: |
+      anchore/grype version with or without the v-prefix
     required: true
   sbomqs_version:
-    description: ''
+    description: |
+      interlynk-io/sbomqs version with or without the v-prefix
     required: true
   cdxgen_plugins_version:
-    description: ''
+    description: |
+      CycloneDX/cdxgen-plugins-bin version.
     required: true
   cdxgen_version:
-    description: ''
+    description: |
+      CycloneDX/cdxgen version.
+      If this is not provided, then the cdxgen_repo and cdxgen_branch inputs need to be set.
     required: false
     default: ''
   cdxgen_repo:
-    description: ''
+    description: |
+      CycloneDX/cdxgen repository name in GitHub without the `.git` suffix.
     required: false
     default: ''
   cdxgen_branch:
-    description: ''
+    description: |
+      CycloneDX/cdxgen branch name in GitHub from which cdxgen will be built from.
     required: false
     default: ''
 outputs:

--- a/.github/actions/install-requirements/action.yaml
+++ b/.github/actions/install-requirements/action.yaml
@@ -1,0 +1,109 @@
+---
+name: 'install-requirements'
+description: ''
+inputs:
+  grype_version:
+    description: ''
+    required: true
+  sbomqs_version:
+    description: ''
+    required: true
+  cdxgen_plugins_version:
+    description: ''
+    required: true
+  cdxgen_version:
+    description: ''
+    required: false
+    default: ''
+  cdxgen_repo:
+    description: ''
+    required: false
+    default: ''
+  cdxgen_branch:
+    description: ''
+    required: false
+    default: ''
+outputs:
+  bin-dir:
+    description: "The directory where the commands are located"
+    value: ${{ steps.location.outputs.dir }}
+runs:
+  using: "composite"
+  steps:
+    - shell: bash
+      run: |
+        if [[ -n "${{ inputs.cdxgen_version }}" ]]; then
+            echo "INFO: cdxgen will be installed using the provided version"
+        elif [[ -n "${{ inputs.cdxgen_repo }}" && -n "${{ inputs.cdxgen_branch }}" ]]; then
+            echo "INFO: cdxgen will be installed using the provided repo + branch"
+        else
+          echo "ERROR: cdxgen_version or cdxgen_repo + cdxgen_branch need to be provided!"
+          exit 1
+        fi
+
+    - shell: bash
+      id: location
+      run: |
+        BIN_PATH="$(pwd)/_bin"
+        mkdir -pv "$BIN_PATH"
+        echo "$BIN_PATH" >> "$GITHUB_PATH"
+        echo "dir=$BIN_PATH" >> "$GITHUB_OUTPUT"
+
+    - shell: bash
+      env:
+        CDXGEN_VERSION: ${{ inputs.cdxgen_version }}
+      if: ${{ -n inputs.cdxgen_version }}
+      run: |
+        echo "Install cdxgen using npm"
+        npm install -g @cyclonedx/cdxgen@${CDXGEN_VERSION}
+
+    - shell: bash
+      env:
+        CDXGEN_REPO: ${{ inputs.cdxgen_repo }}
+        CDXGEN_BRANCH: ${{ inputs.cdxgen_branch }}
+      if: ${{ -n inputs.cdxgen_branch }}
+      run: |
+        echo "Install cdxgen from $CDXGEN_REPO"
+        git clone -b "$CDXGEN_BRANCH" "https://github.com/${CDXGEN_REPO}.git" cdxgen
+        cd cdxgen
+        npm install
+        cd ..
+        ln -s $(realpath cdxgen/bin/cdxgen.js) "${{ steps.location.outputs.dir }}"/cdxgen
+
+    - shell: bash
+      env:
+        CDXGEN_PLUGINS_VERSION: ${{ inputs.cdxgen_plugins_version }}
+      run: |
+        echo "Install cdxgen plugins"
+        npm install -g @cyclonedx/cdxgen-plugins-bin@${CDXGEN_PLUGINS_VERSION}
+
+    - shell: bash
+      env:
+        GRYPE_VERSION: ${{ inputs.grype_version }}
+      run: |
+        echo "Install grype"
+        GRYPE_VERSION="${GRYPE_VERSION#v}"
+        GRYPE_URL="https://github.com/anchore/grype/releases/download/v${GRYPE_VERSION}"
+        curl -Ls "$GRYPE_URL/grype_${GRYPE_VERSION}_linux_amd64.tar.gz" -o grype.tar.gz
+        curl -Ls "$GRYPE_URL/grype_${GRYPE_VERSION}_checksums.txt" -o grype_checksums.txt
+        if ! grep -q "$(sha256sum grype.tar.gz | cut -d' ' -f1)" grype_checksums.txt; then
+            echo "::error title=Invalid checksum::grype ${GRYPE_VERSION}"
+            exit 1
+        fi
+        tar xf grype.tar.gz -C "${{ steps.location.outputs.dir }}"
+
+    - shell: bash
+      env:
+        SBOMQS_VERSION: ${{ inputs.sbomqs_version }}
+      run: |
+        echo "Install sbomqs"
+        SBOMQS_VERSION="${SBOMQS_VERSION#v}"
+        SBOMQS_URL="https://github.com/interlynk-io/sbomqs/releases/download/v${SBOMQS_VERSION}"
+        curl -Ls "$SBOMQS_URL/sbomqs-linux-amd64" -o sbomqs
+        curl -Ls "$SBOMQS_URL/sbomqs_${SBOMQS_VERSION}_checksums.txt" -o sbomqs_checksums.txt
+        if ! grep -q "$(sha256sum sbomqs | cut -d' ' -f1)" sbomqs_checksums.txt; then
+            echo "::error title=Invalid checksum::sbomqs ${SBOMQS_VERSION}"
+            exit 1
+        fi
+        mv sbomqs "${{ steps.location.outputs.dir }}"/sbomqs
+        chmod a+x "${{ steps.location.outputs.dir }}"/sbomqs

--- a/.github/actions/install-requirements/action.yaml
+++ b/.github/actions/install-requirements/action.yaml
@@ -2,115 +2,115 @@
 name: 'install-requirements'
 description: 'Install required dependencies for the build of this application'
 inputs:
-  grype_version:
-    description: |
-      anchore/grype version with or without the v-prefix
-    required: true
-  sbomqs_version:
-    description: |
-      interlynk-io/sbomqs version with or without the v-prefix
-    required: true
-  cdxgen_plugins_version:
-    description: |
-      CycloneDX/cdxgen-plugins-bin version.
-    required: true
-  cdxgen_version:
-    description: |
-      CycloneDX/cdxgen version.
-      If this is not provided, then the cdxgen_repo and cdxgen_branch inputs need to be set.
-    required: false
-    default: ''
-  cdxgen_repo:
-    description: |
-      CycloneDX/cdxgen repository name in GitHub without the `.git` suffix.
-    required: false
-    default: ''
-  cdxgen_branch:
-    description: |
-      CycloneDX/cdxgen branch name in GitHub from which cdxgen will be built from.
-    required: false
-    default: ''
+    grype_version:
+        description: |
+            anchore/grype version with or without the v-prefix
+        required: true
+    sbomqs_version:
+        description: |
+            interlynk-io/sbomqs version with or without the v-prefix
+        required: true
+    cdxgen_plugins_version:
+        description: |
+            CycloneDX/cdxgen-plugins-bin version.
+        required: true
+    cdxgen_version:
+        description: |
+            CycloneDX/cdxgen version.
+            If this is not provided, then the cdxgen_repo and cdxgen_branch inputs need to be set.
+        required: false
+        default: ''
+    cdxgen_repo:
+        description: |
+            CycloneDX/cdxgen repository name in GitHub without the `.git` suffix.
+        required: false
+        default: ''
+    cdxgen_branch:
+        description: |
+            CycloneDX/cdxgen branch name in GitHub from which cdxgen will be built from.
+        required: false
+        default: ''
 outputs:
-  bin-dir:
-    description: "The directory where the commands are located"
-    value: ${{ steps.location.outputs.dir }}
+    bin-dir:
+        description: "The directory where the commands are located"
+        value: ${{ steps.location.outputs.dir }}
 runs:
-  using: "composite"
-  steps:
-    - shell: bash
-      run: |
-        if [[ -n "${{ inputs.cdxgen_version }}" ]]; then
-            echo "INFO: cdxgen will be installed using the provided version"
-        elif [[ -n "${{ inputs.cdxgen_repo }}" && -n "${{ inputs.cdxgen_branch }}" ]]; then
-            echo "INFO: cdxgen will be installed using the provided repo + branch"
-        else
-          echo "ERROR: cdxgen_version or cdxgen_repo + cdxgen_branch need to be provided!"
-          exit 1
-        fi
+    using: "composite"
+    steps:
+        - shell: bash
+          run: |
+              if [[ -n "${{ inputs.cdxgen_version }}" ]]; then
+                  echo "INFO: cdxgen will be installed using the provided version"
+              elif [[ -n "${{ inputs.cdxgen_repo }}" && -n "${{ inputs.cdxgen_branch }}" ]]; then
+                  echo "INFO: cdxgen will be installed using the provided repo + branch"
+              else
+                  echo "ERROR: cdxgen_version or cdxgen_repo + cdxgen_branch need to be provided!"
+                  exit 1
+              fi
 
-    - shell: bash
-      id: location
-      run: |
-        BIN_PATH="$(pwd)/_bin"
-        mkdir -pv "$BIN_PATH"
-        echo "$BIN_PATH" >> "$GITHUB_PATH"
-        echo "dir=$BIN_PATH" >> "$GITHUB_OUTPUT"
+        - shell: bash
+          id: location
+          run: |
+              BIN_PATH="$(pwd)/_bin"
+              mkdir -pv "$BIN_PATH"
+              echo "$BIN_PATH" >> "$GITHUB_PATH"
+              echo "dir=$BIN_PATH" >> "$GITHUB_OUTPUT"
 
-    - shell: bash
-      env:
-        CDXGEN_VERSION: ${{ inputs.cdxgen_version }}
-      if: ${{ inputs.cdxgen_version != '' }}
-      run: |
-        echo "Install cdxgen using npm"
-        npm install -g @cyclonedx/cdxgen@${CDXGEN_VERSION}
+        - shell: bash
+          env:
+              CDXGEN_VERSION: ${{ inputs.cdxgen_version }}
+          if: ${{ inputs.cdxgen_version != '' }}
+          run: |
+              echo "Install cdxgen using npm"
+              npm install -g @cyclonedx/cdxgen@${CDXGEN_VERSION}
 
-    - shell: bash
-      env:
-        CDXGEN_REPO: ${{ inputs.cdxgen_repo }}
-        CDXGEN_BRANCH: ${{ inputs.cdxgen_branch }}
-      if: ${{ inputs.cdxgen_branch != '' }}
-      run: |
-        echo "Install cdxgen from $CDXGEN_REPO"
-        git clone -b "$CDXGEN_BRANCH" "https://github.com/${CDXGEN_REPO}.git" cdxgen
-        cd cdxgen
-        npm install
-        cd ..
-        ln -s $(realpath cdxgen/bin/cdxgen.js) "${{ steps.location.outputs.dir }}"/cdxgen
+        - shell: bash
+          env:
+              CDXGEN_REPO: ${{ inputs.cdxgen_repo }}
+              CDXGEN_BRANCH: ${{ inputs.cdxgen_branch }}
+          if: ${{ inputs.cdxgen_branch != '' }}
+          run: |
+              echo "Install cdxgen from $CDXGEN_REPO"
+              git clone -b "$CDXGEN_BRANCH" "https://github.com/${CDXGEN_REPO}.git" cdxgen
+              cd cdxgen
+              npm install
+              cd ..
+              ln -s $(realpath cdxgen/bin/cdxgen.js) "${{ steps.location.outputs.dir }}"/cdxgen
 
-    - shell: bash
-      env:
-        CDXGEN_PLUGINS_VERSION: ${{ inputs.cdxgen_plugins_version }}
-      run: |
-        echo "Install cdxgen plugins"
-        npm install -g @cyclonedx/cdxgen-plugins-bin@${CDXGEN_PLUGINS_VERSION}
+        - shell: bash
+          env:
+              CDXGEN_PLUGINS_VERSION: ${{ inputs.cdxgen_plugins_version }}
+          run: |
+              echo "Install cdxgen plugins"
+              npm install -g @cyclonedx/cdxgen-plugins-bin@${CDXGEN_PLUGINS_VERSION}
 
-    - shell: bash
-      env:
-        GRYPE_VERSION: ${{ inputs.grype_version }}
-      run: |
-        echo "Install grype"
-        GRYPE_VERSION="${GRYPE_VERSION#v}"
-        GRYPE_URL="https://github.com/anchore/grype/releases/download/v${GRYPE_VERSION}"
-        curl -Ls "$GRYPE_URL/grype_${GRYPE_VERSION}_linux_amd64.tar.gz" -o grype.tar.gz
-        curl -Ls "$GRYPE_URL/grype_${GRYPE_VERSION}_checksums.txt" -o grype_checksums.txt
-        if ! grep -q "$(sha256sum grype.tar.gz | cut -d' ' -f1)" grype_checksums.txt; then
-            echo "::error title=Invalid checksum::grype ${GRYPE_VERSION}"
-            exit 1
-        fi
-        tar xf grype.tar.gz -C "${{ steps.location.outputs.dir }}"
+        - shell: bash
+          env:
+              GRYPE_VERSION: ${{ inputs.grype_version }}
+          run: |
+              echo "Install grype"
+              GRYPE_VERSION="${GRYPE_VERSION#v}"
+              GRYPE_URL="https://github.com/anchore/grype/releases/download/v${GRYPE_VERSION}"
+              curl -Ls "$GRYPE_URL/grype_${GRYPE_VERSION}_linux_amd64.tar.gz" -o grype.tar.gz
+              curl -Ls "$GRYPE_URL/grype_${GRYPE_VERSION}_checksums.txt" -o grype_checksums.txt
+              if ! grep -q "$(sha256sum grype.tar.gz | cut -d' ' -f1)" grype_checksums.txt; then
+                  echo "::error title=Invalid checksum::grype ${GRYPE_VERSION}"
+                  exit 1
+              fi
+              tar xf grype.tar.gz -C "${{ steps.location.outputs.dir }}"
 
-    - shell: bash
-      env:
-        SBOMQS_VERSION: ${{ inputs.sbomqs_version }}
-      run: |
-        echo "Install sbomqs"
-        SBOMQS_VERSION="${SBOMQS_VERSION#v}"
-        SBOMQS_URL="https://github.com/interlynk-io/sbomqs/releases/download/v${SBOMQS_VERSION}"
-        curl -Ls "$SBOMQS_URL/sbomqs-linux-amd64" -o sbomqs
-        curl -Ls "$SBOMQS_URL/sbomqs_${SBOMQS_VERSION}_checksums.txt" -o sbomqs_checksums.txt
-        if ! grep -q "$(sha256sum sbomqs | cut -d' ' -f1)" sbomqs_checksums.txt; then
-            echo "::error title=Invalid checksum::sbomqs ${SBOMQS_VERSION}"
-            exit 1
-        fi
-        mv sbomqs "${{ steps.location.outputs.dir }}"/sbomqs
-        chmod a+x "${{ steps.location.outputs.dir }}"/sbomqs
+        - shell: bash
+          env:
+              SBOMQS_VERSION: ${{ inputs.sbomqs_version }}
+          run: |
+              echo "Install sbomqs"
+              SBOMQS_VERSION="${SBOMQS_VERSION#v}"
+              SBOMQS_URL="https://github.com/interlynk-io/sbomqs/releases/download/v${SBOMQS_VERSION}"
+              curl -Ls "$SBOMQS_URL/sbomqs-linux-amd64" -o sbomqs
+              curl -Ls "$SBOMQS_URL/sbomqs_${SBOMQS_VERSION}_checksums.txt" -o sbomqs_checksums.txt
+              if ! grep -q "$(sha256sum sbomqs | cut -d' ' -f1)" sbomqs_checksums.txt; then
+                   echo "::error title=Invalid checksum::sbomqs ${SBOMQS_VERSION}"
+                   exit 1
+              fi
+              mv sbomqs "${{ steps.location.outputs.dir }}"/sbomqs
+              chmod a+x "${{ steps.location.outputs.dir }}"/sbomqs

--- a/.github/actions/install-requirements/action.yaml
+++ b/.github/actions/install-requirements/action.yaml
@@ -52,7 +52,7 @@ runs:
     - shell: bash
       env:
         CDXGEN_VERSION: ${{ inputs.cdxgen_version }}
-      if: ${{ -n inputs.cdxgen_version }}
+      if: ${{ inputs.cdxgen_version != '' }}
       run: |
         echo "Install cdxgen using npm"
         npm install -g @cyclonedx/cdxgen@${CDXGEN_VERSION}
@@ -61,7 +61,7 @@ runs:
       env:
         CDXGEN_REPO: ${{ inputs.cdxgen_repo }}
         CDXGEN_BRANCH: ${{ inputs.cdxgen_branch }}
-      if: ${{ -n inputs.cdxgen_branch }}
+      if: ${{ inputs.cdxgen_branch != '' }}
       run: |
         echo "Install cdxgen from $CDXGEN_REPO"
         git clone -b "$CDXGEN_BRANCH" "https://github.com/${CDXGEN_REPO}.git" cdxgen

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,17 @@ jobs:
             - name: Set up Docker Buildx
               uses: docker/setup-buildx-action@v3
 
+            - name: Sanity versions
+              env:
+                  GRYPE: ${{ env.GRYPE_VERSION }}
+                  SBOMQS: ${{ env.SBOMQS_VERSION }}
+              run: |
+                  echo "Sanity provided versions for docker build"
+                  {
+                      echo "GRYPE_VERSION=${GRYPE#v}"
+                      echo "SBOMQS_VERSION=${SBOMQS#v}"
+                  } >> "$GITHUB_ENV"
+
             - name: Docker build
               uses: docker/build-push-action@v5
               with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,34 +48,12 @@ jobs:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
             - name: Install requirements
-              run: |
-                  echo "Install cdxgen"
-                  npm install -g @cyclonedx/cdxgen@${CDXGEN_VERSION}
-                  npm install -g @cyclonedx/cdxgen-plugins-bin@${CDXGEN_PLUGINS_VERSION}
-
-                  mkdir _bin
-                  echo $(pwd)/_bin >> $GITHUB_PATH
-
-                  echo "Install grype"
-                  GRYPE_URL="https://github.com/anchore/grype/releases/download/v${GRYPE_VERSION}"
-                  curl -Ls "$GRYPE_URL/grype_${GRYPE_VERSION}_linux_amd64.tar.gz" -o grype.tar.gz
-                  curl -Ls "$GRYPE_URL/grype_${GRYPE_VERSION}_checksums.txt" -o grype_checksums.txt
-                  if ! grep -q "$(sha256sum grype.tar.gz | cut -d' ' -f1)" grype_checksums.txt; then
-                      echo "::error title=Invalid checksum::grype ${GRYPE_VERSION}"
-                      exit 1
-                  fi
-                  tar xf grype.tar.gz -C _bin
-
-                  echo "Install sbomqs"
-                  SBOMQS_URL="https://github.com/interlynk-io/sbomqs/releases/download/v${SBOMQS_VERSION}"
-                  curl -Ls "$SBOMQS_URL/sbomqs-linux-amd64" -o sbomqs
-                  curl -Ls "$SBOMQS_URL/sbomqs_${SBOMQS_VERSION}_checksums.txt" -o sbomqs_checksums.txt
-                  if ! grep -q "$(sha256sum sbomqs | cut -d' ' -f1)" sbomqs_checksums.txt; then
-                      echo "::error title=Invalid checksum::sbomqs ${SBOMQS_VERSION}"
-                      exit 1
-                  fi
-                  mv sbomqs _bin/sbomqs
-                  chmod a+x _bin/sbomqs
+              uses: ./.github/actions/install-requirements
+              with:
+                  grype_version: ${{ env.GRYPE_VERSION }}
+                  sbomqs_version: ${{ env.SBOMQS_VERSION }}
+                  cdxgen_version: ${{ env.CDXGEN_VERSION }}
+                  cdxgen_plugins_version: ${{ env.CDXGEN_PLUGINS_VERSION }}
 
             - name: Application Build and Test
               env:

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -32,41 +32,14 @@ jobs:
                   java-version: '${{ env.java_version }}'
                   distribution: 'temurin'
 
-            - name: Install requirements and cdxgen from repo ${{env.cdxgen_repo}} branch ${{ env.cdxgen_branch }}
-              run: |
-                  mkdir _bin
-                  echo $(pwd)/_bin >> $GITHUB_PATH
-
-                  # cdxgen
-                  git clone -b "$cdxgen_branch" "https://github.com/${cdxgen_repo}.git" cdxgen
-                  cd cdxgen
-                  npm install
-                  cd ..
-                  ln -s $(realpath cdxgen/bin/cdxgen.js) _bin/cdxgen
-
-                  # cdxgen-plugins-bin
-                  npm install -g @cyclonedx/cdxgen-plugins-bin@${CDXGEN_PLUGINS_VERSION}
-
-                  echo "Install grype"
-                  GRYPE_URL="https://github.com/anchore/grype/releases/download/v${GRYPE_VERSION}"
-                  curl -Ls "$GRYPE_URL/grype_${GRYPE_VERSION}_linux_amd64.tar.gz" -o grype.tar.gz
-                  curl -Ls "$GRYPE_URL/grype_${GRYPE_VERSION}_checksums.txt" -o grype_checksums.txt
-                  if ! grep -q "$(sha256sum grype.tar.gz | cut -d' ' -f1)" grype_checksums.txt; then
-                      echo "::error title=Invalid checksum::grype ${GRYPE_VERSION}"
-                      exit 1
-                  fi
-                  tar xf grype.tar.gz -C _bin
-
-                  echo "Install sbomqs"
-                  SBOMQS_URL="https://github.com/interlynk-io/sbomqs/releases/download/v${SBOMQS_VERSION}"
-                  curl -Ls "$SBOMQS_URL/sbomqs-linux-amd64" -o sbomqs
-                  curl -Ls "$SBOMQS_URL/sbomqs_${SBOMQS_VERSION}_checksums.txt" -o sbomqs_checksums.txt
-                  if ! grep -q "$(sha256sum sbomqs | cut -d' ' -f1)" sbomqs_checksums.txt; then
-                      echo "::error title=Invalid checksum::sbomqs ${SBOMQS_VERSION}"
-                      exit 1
-                  fi
-                  mv sbomqs _bin/sbomqs
-                  chmod a+x _bin/sbomqs
+            - name: Install requirements
+              uses: ./.github/actions/install-requirements
+              with:
+                  grype_version: ${{ env.GRYPE_VERSION }}
+                  sbomqs_version: ${{ env.SBOMQS_VERSION }}
+                  cdxgen_plugins_version: ${{ env.CDXGEN_PLUGINS_VERSION }}
+                  cdxgen_repo: ${{ env.cdxgen_repo }}
+                  cdxgen_branch: ${{ env.cdxgen_branch }}
 
             - name: Application Build and Test with cdxgen branch ${{ env.cdxgen_branch }}
               env:


### PR DESCRIPTION
Install all requirements in a composite action, which can be re-used
in both ci and verify workflows to reduce code duplication.

Also sanity the input for grype and sbomqs versions, because renovate
update these sometimes with and other times without a `v` prefix.
