### PR TITLE
fix: adjust parsing of app.allowed_env_substitutions

### DIFF
--- a/src/main/java/com/mediamarktsaturn/technolinator/sbom/CdxgenClient.java
+++ b/src/main/java/com/mediamarktsaturn/technolinator/sbom/CdxgenClient.java
@@ -19,6 +19,7 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -94,9 +95,10 @@ public class CdxgenClient {
         this.recursiveDefault = config.getValue("analysis.recursive_default", Boolean.TYPE);
         this.failOnError = config.getValue("cdxgen.fail_on_error", Boolean.TYPE);
 
-        this.allowedEnvSubstitutions = Arrays.stream(
-            config.getValue("app.allowed_env_substitutions", String.class).split(",")
-        ).map(String::trim).toList();
+        this.allowedEnvSubstitutions = config.getOptionalValue("app.allowed_env_substitutions", String.class)
+            .filter(str -> !str.isBlank())
+            .map(str -> Arrays.stream(str.split(",")).map(String::trim).toList())
+            .orElse(Collections.emptyList());
 
         // https://github.com/AppThreat/cdxgen#environment-variables
         this.cdxgenEnv = Map.of(

--- a/src/main/java/com/mediamarktsaturn/technolinator/sbom/CdxgenClient.java
+++ b/src/main/java/com/mediamarktsaturn/technolinator/sbom/CdxgenClient.java
@@ -80,7 +80,7 @@ public class CdxgenClient {
     /**
      * Variable names that are allowed to be resolved from ENV.
      */
-    private final List<String> allowedEnvSubstitutions;
+    final List<String> allowedEnvSubstitutions;
 
     /**
      * Configurable, supported jdk versions.

--- a/src/test/java/com/mediamarktsaturn/technolinator/CustomTestProfiles.java
+++ b/src/test/java/com/mediamarktsaturn/technolinator/CustomTestProfiles.java
@@ -1,0 +1,23 @@
+package com.mediamarktsaturn.technolinator;
+
+import io.quarkus.test.junit.QuarkusTestProfile;
+
+import java.util.Collections;
+import java.util.Map;
+
+public class CustomTestProfiles {
+
+    public static class AllowedEnvSubstitutions implements QuarkusTestProfile {
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Collections.singletonMap("app.allowed_env_substitutions", "substitution.1,substitution.2");
+        }
+    }
+
+    public static class EmptyAllowedEnvSubstitutions implements QuarkusTestProfile {
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Collections.singletonMap("app.allowed_env_substitutions", "   ");
+        }
+    }
+}

--- a/src/test/java/com/mediamarktsaturn/technolinator/sbom/CdxgenClientOptionalEnvTest.java
+++ b/src/test/java/com/mediamarktsaturn/technolinator/sbom/CdxgenClientOptionalEnvTest.java
@@ -1,0 +1,36 @@
+package com.mediamarktsaturn.technolinator.sbom;
+
+import com.mediamarktsaturn.technolinator.CustomTestProfiles;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@QuarkusTest
+@TestProfile(CustomTestProfiles.EmptyAllowedEnvSubstitutions.class)
+class CdxgenClientEmptyAllowedEnvSubstitutionsTest {
+
+    @Inject
+    CdxgenClient cut;
+
+    @Test
+    void testEmptyAllowedEnvSubstitutionsIsParsedWithoutError() {
+        assertThat(cut.allowedEnvSubstitutions).isEmpty();
+    }
+}
+
+@QuarkusTest
+@TestProfile(CustomTestProfiles.AllowedEnvSubstitutions.class)
+class CdxgenClientAllowedEnvSubstitutionsTest {
+
+    @Inject
+    CdxgenClient cut;
+
+    @Test
+    void testEmptyAllowedEnvSubstitutionsIsParsedWithoutError() {
+        assertThat(cut.allowedEnvSubstitutions).hasSize(2);
+        assertThat(cut.allowedEnvSubstitutions).containsExactlyInAnyOrder("substitution.1", "substitution.2");
+    }
+}


### PR DESCRIPTION
SmallRyeConfig `getValue` doesn't allow the provided configured value to
be empty, therefore use `getOptionalValue` instead.

See also: https://github.com/eclipse/microprofile-config/pull/407

Fixes #303
