### PR TITLE
ci(actions): add workflow to comment on opened issue

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -2,10 +2,6 @@ name: Bug Report
 description: File a bug report
 title: "[Bug]: "
 labels: [ "bug" ]
-assignees:
-  - heubeck
-  - johannesmarx
-  - beiertu-mms
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -2,10 +2,6 @@ name: Feature Request
 description: Request a new feature
 title: "[FEAT]: "
 labels: [ "enhancement" ]
-assignees:
-  - heubeck
-  - johannesmarx
-  - beiertu-mms
 body:
   - type: markdown
     attributes:

--- a/.github/workflows/assign_issue.yml
+++ b/.github/workflows/assign_issue.yml
@@ -17,6 +17,6 @@ jobs:
           GH_REPO: ${{ github.repository }}
           NUMBER: ${{ github.event.issue.number }}
           BODY: |-
-            Thank you for taking your time to inform us about this. :heart:
+            Thank you for taking your time to reach out. :heart:
 
             @MediaMarktSaturn/software-supply-chain-security :eyes:

--- a/.github/workflows/assign_issue.yml
+++ b/.github/workflows/assign_issue.yml
@@ -1,0 +1,22 @@
+---
+name: "Assign issue"
+"on":
+  issues:
+    types:
+      - opened
+jobs:
+  add-comment:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - run: |
+          gh issue comment "$NUMBER" --body "$BODY"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          NUMBER: ${{ github.event.issue.number }}
+          BODY: |-
+            Thank you for taking your time to inform us about this. :heart:
+
+            @MediaMarktSaturn/software-supply-chain-security :eyes:


### PR DESCRIPTION
Add a new workflow to thank the issue creator. And mention the team
instead of assign the issue to a small list of people, so that more
members are made aware of the issue.

Based on this guide
- https://docs.github.com/en/actions/managing-issues-and-pull-requests/commenting-on-an-issue-when-a-label-is-added
