### PR TITLE
feat: make commit status update configurable

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -30,6 +30,7 @@ depscan.template=${DEPSCAN_TEMPLATE:src/main/docker/assets/depscan.j2}
 analysis.recursive_default=${ANALYSIS_RECURSIVE_DEFAULT:true}
 
 app.use_pending_commit_status=${APP_USE_PENDING_COMMIT_STATUS:false}
+app.commit_status_write.enabled=${APP_COMMIT_STATUS_WRITE_ENABLED:true}
 app.clean_wrapper_scripts=${APP_CLEAN_WRAPPER_SCRIPTS:false}
 %test.app.clean_wrapper_scripts=${APP_CLEAN_WRAPPER_SCRIPTS:false}
 

--- a/src/test/java/com/mediamarktsaturn/technolinator/CustomTestProfiles.java
+++ b/src/test/java/com/mediamarktsaturn/technolinator/CustomTestProfiles.java
@@ -20,4 +20,11 @@ public class CustomTestProfiles {
             return Collections.singletonMap("app.allowed_env_substitutions", "   ");
         }
     }
+
+    public static class CommitStatusWriteDisabled implements QuarkusTestProfile {
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Collections.singletonMap("app.commit_status_write.enabled", "false");
+        }
+    }
 }

--- a/src/test/java/com/mediamarktsaturn/technolinator/events/OnPushDispatcherTest.java
+++ b/src/test/java/com/mediamarktsaturn/technolinator/events/OnPushDispatcherTest.java
@@ -1,6 +1,7 @@
 package com.mediamarktsaturn.technolinator.events;
 
 import com.mediamarktsaturn.technolinator.ConfigBuilder;
+import com.mediamarktsaturn.technolinator.CustomTestProfiles;
 import com.mediamarktsaturn.technolinator.Result;
 import com.mediamarktsaturn.technolinator.git.TechnolinatorConfig;
 import com.mediamarktsaturn.technolinator.handler.PushHandler;
@@ -9,6 +10,7 @@ import io.quarkiverse.githubapp.testing.GitHubAppTest;
 import io.quarkiverse.githubapp.testing.GitHubAppTesting;
 import io.quarkus.test.InjectMock;
 import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
 import io.restassured.RestAssured;
 import io.smallrye.mutiny.Uni;
 import org.hamcrest.CoreMatchers;
@@ -19,7 +21,6 @@ import org.mockito.ArgumentMatcher;
 import org.mockito.Mockito;
 
 import java.io.IOException;
-import java.net.MalformedURLException;
 import java.util.List;
 import java.util.Optional;
 
@@ -69,9 +70,7 @@ class OnPushDispatcherTest {
 
         // When
         GitHubAppTesting.given()
-            .github(mocks -> {
-                mocks.configFile(CONFIG_FILE).fromClasspath("/configs/project_name_override.yml");
-            })
+            .github(mocks -> mocks.configFile(CONFIG_FILE).fromClasspath("/configs/project_name_override.yml"))
             .when()
             .payloadFromClasspath("/events/push_to_default_branch.json")
             .event(GHEvent.PUSH);
@@ -84,9 +83,7 @@ class OnPushDispatcherTest {
     void testConfigDisabled() throws IOException {
         // When
         GitHubAppTesting.given()
-            .github(mocks -> {
-                mocks.configFile(CONFIG_FILE).fromClasspath("/configs/disabled.yml");
-            })
+            .github(mocks -> mocks.configFile(CONFIG_FILE).fromClasspath("/configs/disabled.yml"))
             .when()
             .payloadFromClasspath("/events/push_to_default_branch.json")
             .event(GHEvent.PUSH);
@@ -106,9 +103,7 @@ class OnPushDispatcherTest {
 
         // When
         GitHubAppTesting.given()
-            .github(mocks -> {
-                mocks.configFile(CONFIG_FILE).fromClasspath("/configs/full_blown.yml");
-            })
+            .github(mocks -> mocks.configFile(CONFIG_FILE).fromClasspath("/configs/full_blown.yml"))
             .when()
             .payloadFromClasspath("/events/push_to_default_branch.json")
             .event(GHEvent.PUSH);
@@ -118,7 +113,7 @@ class OnPushDispatcherTest {
     }
 
     @Test
-    void testRepoEnabledConfig_noRestriction() throws MalformedURLException {
+    void testRepoEnabledConfig_noRestriction() {
         // Given
         var cur = new OnPushDispatcher();
         cur.enabledRepos = List.of();
@@ -128,7 +123,7 @@ class OnPushDispatcherTest {
     }
 
     @Test
-    void testRepoEnabledConfig_restriction() throws MalformedURLException {
+    void testRepoEnabledConfig_restriction() {
         // Given
         var cur = new OnPushDispatcher();
         cur.enabledRepos = List.of(" technolinator ", "", " analyzeMe");

--- a/src/test/java/com/mediamarktsaturn/technolinator/events/OnPushDispatcherWithDisabledCommitStatusWriteTest.java
+++ b/src/test/java/com/mediamarktsaturn/technolinator/events/OnPushDispatcherWithDisabledCommitStatusWriteTest.java
@@ -1,0 +1,58 @@
+package com.mediamarktsaturn.technolinator.events;
+
+import com.mediamarktsaturn.technolinator.CustomTestProfiles;
+import com.mediamarktsaturn.technolinator.handler.PushHandler;
+import io.quarkiverse.githubapp.testing.GitHubAppTest;
+import io.quarkiverse.githubapp.testing.GitHubAppTesting;
+import io.quarkus.test.InjectMock;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.restassured.RestAssured;
+import org.hamcrest.CoreMatchers;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.kohsuke.github.GHEvent;
+import org.mockito.Mockito;
+
+import java.io.IOException;
+
+import static org.awaitility.Awaitility.await;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+
+@QuarkusTest
+@GitHubAppTest
+@TestProfile(CustomTestProfiles.CommitStatusWriteDisabled.class)
+class OnPushDispatcherWithDisabledCommitStatusWriteTest {
+
+    @InjectMock
+    PushHandler handler;
+
+    @BeforeEach
+    void setup() {
+        Mockito.reset(handler);
+    }
+
+    @Test
+    void testOnPushToDefaultBranch() throws IOException {
+        // When
+        GitHubAppTesting.when()
+            .payloadFromClasspath("/events/push_to_default_branch.json")
+            .event(GHEvent.PUSH)
+            .then()
+            .github(mocks -> Mockito
+                .verify(mocks.repository("heubeck/app-test"), Mockito.never())
+                .createCommitStatus(any(), any(), any(), any(), any()));
+
+        // Then
+        await().untilAsserted(() -> Mockito.verify(handler)
+            .onPush(argThat(OnPushDispatcherTest.matches("https://github.com/heubeck/app-test", "refs/heads/main", "main", null)), any()));
+
+        RestAssured.get("/q/metrics")
+            .then()
+            .statusCode(200)
+            .body(CoreMatchers.containsString("""
+                repo_analysis_current_count{kind="push",repo="app-test"} 1.0
+                """));
+    }
+}


### PR DESCRIPTION
Add a new application configuration to disable the commit status update
for all repositories in case permissions are not yet given.

Closes #306.
