### PR TITLE
ci(actions): close dependabot pull requests for src/test

### DIFF
--- a/.github/workflows/close_dependabot_pr.yaml
+++ b/.github/workflows/close_dependabot_pr.yaml
@@ -1,0 +1,22 @@
+---
+name: "Close Dependabot Pull Request"
+
+"on":
+  pull_request_target:
+    types:
+      - "opened"
+      - "reopened"
+    branches:
+      - "main"
+    paths:
+      - "src/test/**"
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    steps:
+      - uses: superbrothers/close-pull-request@v3
+        with:
+          comment: "@dependabot ignore this dependency"


### PR DESCRIPTION
Use a new workflow to automatically close any dependabot pull requests
created for `src/test` because the feature to ignore specific folders
isn't yet available by dependabot core team.

See also https://github.com/superbrothers/close-pull-request

Solved #229.
