### PR TITLE
ci(actions): skip ci for non relevant changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,7 @@ jobs:
             **/*.md
             .github/dependabot.yml
             .github/technolinator.yml
+            .github/workflows/ci.yml
 
   skip_ci:
     # Use the same name as CI build as workaround for required status checks for pull requests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,6 @@ jobs:
             **/*.md
             .github/dependabot.yml
             .github/technolinator.yml
-            .github/workflows/ci.yml
 
   skip_ci:
     # Use the same name as CI build as workaround for required status checks for pull requests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,13 +1,12 @@
+---
 name: Application build and test
 on:
   push:
-    paths-ignore:
-      - 'README.md'
-      - '.github/dependabot.yml'
-      - '.github/technolinator.yml'
+
 concurrency:
   group: ${{ github.ref }}-${{ github.workflow }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 env:
   CDXGEN_VERSION: '9.11.2'
   CDXGEN_PLUGINS_VERSION: '1.5.4'
@@ -20,12 +19,44 @@ env:
   mvn_parameter: '-B -ntp'
   image_name: 'ghcr.io/mediamarktsaturn/technolinator'
 jobs:
-  ci:
-    name: Application Build
+  preparation:
+    name: Preparation
     runs-on: ubuntu-latest
     if: |
       github.actor != 'dependabot[bot]' ||
       (github.actor == 'dependabot[bot]' &&  github.ref != 'refs/heads/main')
+    outputs:
+      has_changes: ${{ steps.changed-files.outputs.any_changed }}
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Get relevant changes
+        id: changed-files
+        uses: tj-actions/changed-files@v42
+        with:
+          files_ignore: |
+            **/*.md
+            .github/dependabot.yml
+            .github/technolinator.yml
+
+  skip_ci:
+    # Use the same name as CI build as workaround for required status checks for pull requests
+    # See https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks#handling-skipped-but-required-checks
+    name: Application Build
+    runs-on: ubuntu-latest
+    needs: preparation
+    if: needs.preparation.outputs.has_changes == 'false'
+    steps:
+      - run: echo 'Skip build because no relevant files have been changed.'
+
+  ci:
+    name: Application Build
+    runs-on: ubuntu-latest
+    needs: preparation
+    if: needs.preparation.outputs.has_changes == 'true'
     steps:
 
       - name: Checkout Code


### PR DESCRIPTION
Currently any standalone changes to the readme don't trigger the CI,
which causes the pull request to be blocked because the CI build is
set as required.
To workaround this, use a prep job to check for relevant changes and
trigger a skip job for trivial changes like readme updates.
