### PR TITLE
[CAPA-1004] Assignment of repository to application/product

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -6,10 +6,10 @@ metadata:
   description: "GitHub app for SBOM creation using cdxgen and upload to Dependency-Track"
   annotations:
     github.com/project-slug: MediaMarktSaturn/technolinator # https://backstage.io/docs/features/software-catalog/well-known-annotations/#githubcomproject-slug
-    github.com/team-slug: MediaMarktSaturn/<TEAM> # https://backstage.io/docs/features/software-catalog/well-known-annotations/#githubcomteam-slug
-    mms.tech/product_id: "<PRODUCT_ID>" # https://lookerstudio.google.com/u/0/reporting/12072637-58fe-4f6e-8509-9dc00c806962/page/p_4kaxep2g1c
-    mms.tech/app_id: <APP_ID> # https://mms.cherwellondemand.com/CherwellClient/Access/Dashboard/IT%20Product%20Catalog
+    github.com/team-slug: MediaMarktSaturn/software-supply-chain-security
+    mms.tech/product_id: '6239'
+    mms.tech/app_id: ''
 spec:
-  type: <TYPE> # like service, website, library
-  lifecycle: <LIFECYCLE> # like production, experimental, deprecated
-  owner: <OWNER> # product team or owner
+  type: service  # alternatives: website, library
+  lifecycle: production # alternative: experimental, deprecated
+  owner: Cyber Security

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,15 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: technolinator
+  title: technolinator
+  description: "GitHub app for SBOM creation using cdxgen and upload to Dependency-Track"
+  annotations:
+    github.com/project-slug: MediaMarktSaturn/technolinator # https://backstage.io/docs/features/software-catalog/well-known-annotations/#githubcomproject-slug
+    github.com/team-slug: MediaMarktSaturn/<TEAM> # https://backstage.io/docs/features/software-catalog/well-known-annotations/#githubcomteam-slug
+    mms.tech/product_id: "<PRODUCT_ID>" # https://lookerstudio.google.com/u/0/reporting/12072637-58fe-4f6e-8509-9dc00c806962/page/p_4kaxep2g1c
+    mms.tech/app_id: <APP_ID> # https://mms.cherwellondemand.com/CherwellClient/Access/Dashboard/IT%20Product%20Catalog
+spec:
+  type: <TYPE> # like service, website, library
+  lifecycle: <LIFECYCLE> # like production, experimental, deprecated
+  owner: <OWNER> # product team or owner


### PR DESCRIPTION
# Assign the repository to the application and/or product team

This pull request adds a metadata file to assign your repository to the corresponding MMS entities. Please check and replace the placeholders with the values valid for your team and repository.
The mapping is part of the Security initiative and will be enforced for all repositories. Please do not ignore and discard this pull request. Instead, adjust the following values carefully to enable cataloging with the Backstage tool.

Please note that the pull request should be reviewed and merged **no later than February 29, 2024**.

## Values to be replaced

\<TEAM\>
\<PRODUCT_ID\>
\<APP_ID\>
\<TYPE\>
\<LIFECYCLE\>
\<OWNER\>

## Note

The decision has not yet been made, but we would like to introduce the Backstage as a developer portal. The tool was chosen because it is the best fit for us. The metadata format was defined together with the principal engineers.
If required, further metadata can be specified. Follow the instructions in this [documentation](https://backstage.io/docs/features/software-catalog/descriptor-format).