### PR TITLE
build(mvn): bump quarkus from 3.7.4 to 3.8.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-        <quarkus.platform.version>3.7.4</quarkus.platform.version>
+        <quarkus.platform.version>3.8.1</quarkus.platform.version>
 
         <quarkus-github-app.version>2.3.1</quarkus-github-app.version>
 


### PR DESCRIPTION
Release: https://github.com/quarkusio/quarkus/releases/tag/3.8.1
Changelog: https://github.com/quarkusio/quarkus/compare/3.7.4...3.8.1
