### PR TITLE
ci(actions): adjust workflow triggers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,11 @@
 name: Application build and test
 on:
   push:
+    branches:
+      - "main"
+  pull_request_target:
+    branches:
+      - "main"
 
 concurrency:
   group: ${{ github.ref }}-${{ github.workflow }}
@@ -42,6 +47,7 @@ jobs:
         with:
           files_ignore: |
             **/*.md
+            docs/
             .github/dependabot.yml
             .github/technolinator.yml
 


### PR DESCRIPTION
Add the `pull_request_target` trigger, so that pull requests from a
fork will also start a build. Otherwise they can't be verified.

A downside to this is that changes to the CI workflow can't be directly
verified on a pull request anymore without some workarounds, because
the CI will now run in the context of the base of the pull request.

Closes #378.

See also:
- https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target
