### PR TITLE
ci(actions): adjust build trigger check for dependabot

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     if: |
       github.actor != 'dependabot[bot]' ||
-      (github.actor == 'dependabot[bot]' &&  github.ref != 'refs/heads/main')
+      (github.actor == 'dependabot[bot]' &&  github.event_name == 'pull_request_target')
     outputs:
       has_changes: ${{ steps.changed-files.outputs.any_changed }}
     steps:


### PR DESCRIPTION
With the check using `github.ref` and dependabot as an actor, the build
is skipped. Previously, only the `push` trigger exists and will trigger
the workflow. As the `pull_request_target` has been added to also allow
pull requests from forks to trigger the workflow, the check needs to be
adjusted.

Related to:
- https://github.com/MediaMarktSaturn/technolinator/issues/378
