### PR TITLE
revert: bump quarkus-github-app.version from 2.3.3 to 2.4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.version>3.8.2</quarkus.platform.version>
 
-        <quarkus-github-app.version>2.4.0</quarkus-github-app.version>
+        <quarkus-github-app.version>2.3.3</quarkus-github-app.version>
 
         <cyclonedx-core-java.version>8.0.3</cyclonedx-core-java.version>
         <jruby.jcodings.version>1.0.58</jruby.jcodings.version>


### PR DESCRIPTION
Revert this dependency update because it causes test to fail.

This reverts commit 1a0b2a7d2c56634c83af07b9deb6c45860ad6921.

See also #397
