### PR TITLE
test: adjust RepositoryServiceTest.testInvalidBranch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,11 +2,6 @@
 name: Application build and test
 on:
   push:
-    branches:
-      - "main"
-  pull_request_target:
-    branches:
-      - "main"
 
 concurrency:
   group: ${{ github.ref }}-${{ github.workflow }}
@@ -32,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     if: |
       github.actor != 'dependabot[bot]' ||
-      (github.actor == 'dependabot[bot]' &&  github.event_name == 'pull_request_target')
+      (github.actor == 'dependabot[bot]' && github.ref != 'refs/heads/main')
     outputs:
       has_changes: ${{ steps.changed-files.outputs.any_changed }}
     steps:

--- a/src/test/java/com/mediamarktsaturn/technolinator/git/RepositoryServiceTest.java
+++ b/src/test/java/com/mediamarktsaturn/technolinator/git/RepositoryServiceTest.java
@@ -42,8 +42,8 @@ class RepositoryServiceTest {
 
     @ParameterizedTest
     @CsvSource({
-        "heubeck/examiner, refs/heads/main, pom.xml",
-        "jug-in/jug-in.bayern, refs/heads/master, README.md",
+        "heubeck/examiner,     refs/heads/main,     pom.xml",
+        "jug-in/jug-in.bayern, refs/heads/master,   README.md",
         "jug-in/jug-in.bayern, refs/heads/gh-pages, index.html"
     })
     void testSuccessfulCheckout(String repoName, String branch, String checkFile) throws IOException {
@@ -82,9 +82,12 @@ class RepositoryServiceTest {
 
 
         // Then
-        assertThat(result).isInstanceOfSatisfying(Result.Failure.class, failure -> {
-            assertThat(failure.cause().toString()).hasToString("org.kohsuke.github.GHFileNotFoundException: https://api.github.com/repos/heubeck/examiner/zipball/never/ever 404: Not Found");
-        });
+        assertThat(result).isInstanceOfSatisfying(Result.Failure.class, failure ->
+            assertThat(failure.cause().toString())
+                .startsWith("org.kohsuke.github.GHFileNotFoundException: https://")
+                .contains("/heubeck/examiner/")
+                .endsWith("/never/ever 404: Not Found")
+        );
     }
 
 }


### PR DESCRIPTION
The `GHFileNotFoundException` message has been changed and therefore
the test validation needs to be adjusted.

Also switch back `push` only trigger, because the`pull_request_target`
trigger runs on the main branch context, so it won't verify the actual
changes in a pull request.
Therefore, re-open the issue #378.

