### PR TITLE
ci(actions): fix no space left on device error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,16 @@ jobs:
     needs: preparation
     if: needs.preparation.outputs.has_changes == 'true'
     steps:
+      - name: Free disk space
+        run: |
+          df -h
+          echo "----------------------------------------"
+
+          sudo swapoff -a
+          sudo rm -f /swapfile
+          sudo apt clean
+          docker rmi $(docker image ls -aq)
+          df -h
 
       - name: Checkout Code
         uses: actions/checkout@v4


### PR DESCRIPTION
Currently the builds on main are failing with the error
`System.IO.IOException: No space left on device`.
See for example the runs
- https://github.com/MediaMarktSaturn/technolinator/actions/runs/8566012762
- https://github.com/MediaMarktSaturn/technolinator/actions/runs/8566139722

Therefore, follow the suggestion in this comment
- https://github.com/orgs/community/discussions/26351#discussioncomment-3251595

to free up space on GitHub runner, before running the CI.
