### PR TITLE
fix(ci): pin conventional-changelog-conventionalcommits to 7.0.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ jobs:
           distribution: 'temurin'
 
       - name: Install dependencies for semantic-release-action
-        run: npm install -D conventional-changelog-conventionalcommits
+        run: npm install -D conventional-changelog-conventionalcommits@7.0.2
 
       - name: Getting next release version
         id: semantic


### PR DESCRIPTION
The latest major version (`8.0.0`) containing breaking changes, which
are not yet included in release-notes-generator.
Therefore, pin its version to the previous release for now to not
block any further releases.

See issue:
- https://github.com/semantic-release/release-notes-generator/issues/633
