### PR TITLE
chore(action): publish test reports on failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,6 +125,14 @@ jobs:
           VERSION=$(mvn org.apache.maven.plugins:maven-help-plugin:3.3.0:evaluate -Dexpression=project.version -q -DforceStdout)
           echo VERSION="$VERSION" >> $GITHUB_ENV
 
+      - name: Publish Test Report
+        if: ${{ failure() }}
+        uses: scacap/action-surefire-report@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          fail_if_no_tests: false
+          create_check: false
+
       - name: Static code analysis
         if: github.ref == 'refs/heads/main' && steps.semantic.outputs.new_release_version != null
         env:


### PR DESCRIPTION
Use the `scacap/action-surefire-report`
to publish the test reports from maven surefire,
so that it's easier to identify the actual failing tests,
without having going through the whole logs.

See also:
- https://github.com/scacap/action-surefire-report