### PR TITLE
build(mvn): bump quarkus-bom from 3.18.2 to 3.18.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-        <quarkus.platform.version>3.18.2</quarkus.platform.version>
+        <quarkus.platform.version>3.18.3</quarkus.platform.version>
 
         <quarkus-github-app.version>2.8.4</quarkus-github-app.version>
 


### PR DESCRIPTION
Release: https://github.com/quarkusio/quarkus/releases/tag/3.18.3
Full diff: https://github.com/quarkusio/quarkus-platform/compare/3.18.2...3.18.3
