### PR TITLE
fix(ci): run on pull request

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,15 @@
 name: Application build and test
 on:
   push:
+    branches:
+      - 'main'
+  pull_request:
+    branches:
+      - 'main'
+    types:
+      - opened
+      - reopened
+      - synchronize
 
 concurrency:
   group: ${{ github.ref }}-${{ github.workflow }}


### PR DESCRIPTION
Approval for running fork pull request feature will only work when
the workflow is triggered via `pull_request`, see also
- https://github.com/orgs/community/discussions/119459#discussioncomment-9180402

Therefore, add this as an additional triggers to the CI workflow.
And change this repository setting

Fixes:
- https://github.com/MediaMarktSaturn/technolinator/issues/378
