### PR TITLE
fix: Disable license fetching and update Quarkus

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 env:
-  CDXGEN_VERSION: '11.8.0'
+  CDXGEN_VERSION: '11.9.0'
   CDXGEN_PLUGINS_VERSION: '1.7.0'
   GRYPE_VERSION: 'v0.100.0'
   SBOMQS_VERSION: 'v1.2.0'

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-        <quarkus.platform.version>3.28.1</quarkus.platform.version>
+        <quarkus.platform.version>3.28.2</quarkus.platform.version>
 
         <quarkus-github-app.version>2.12.1</quarkus-github-app.version>
 
@@ -34,7 +34,7 @@
         <surefire-plugin.version>3.5.4</surefire-plugin.version>
         <compiler-plugin.version>3.14.1</compiler-plugin.version>
         <clean-plugin.version>3.5.0</clean-plugin.version>
-        <dependency-plugin.version>3.8.1</dependency-plugin.version>
+        <dependency-plugin.version>3.9.0</dependency-plugin.version>
         <maven-license-plugin.version>2.7.0</maven-license-plugin.version>
     </properties>
     <dependencyManagement>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -49,7 +49,8 @@ app.allowed_env_substitutions=${ALLOWED_ENV_SUBSTITUTIONS: }
 
 app.enabled_repos=${APP_ENABLED_REPOS: }
 app.analysis_timeout=${APP_ANALYSIS_TIMEOUT:60M}
-app.analysis.cdxgen.fetch_licenses=${APP_ANALYSIS_CDXGEN_FETCH_LICENSES:true}
+# TODO: re-enable license fetching after https://github.com/CycloneDX/cdxgen/issues/2058 got resolved
+app.analysis.cdxgen.fetch_licenses=${APP_ANALYSIS_CDXGEN_FETCH_LICENSES:false}
 
 app.pull_requests.ignore_bots=${APP_PULL_REQUESTS_IGNORE_BOTS:true}
 app.pull_requests.enabled=${APP_PULL_REQUESTS_ENABLED:true}

--- a/src/test/java/com/mediamarktsaturn/technolinator/os/ProcessHandlerTest.java
+++ b/src/test/java/com/mediamarktsaturn/technolinator/os/ProcessHandlerTest.java
@@ -53,7 +53,7 @@ class ProcessHandlerTest {
 
         // Then
         assertThat(result).isInstanceOfSatisfying(ProcessHandler.ProcessResult.Failure.class, failure -> {
-            assertThat(failure.cause().getCause()).hasToString("java.io.IOException: Cannot run program \"moep\" (in directory \".\"): error=2, No such file or directory");
+            assertThat(failure.cause().getCause()).isInstanceOf(java.io.IOException.class).hasMessageContaining("Cannot run program \"moep\" (in directory \".\")");
         });
     }
 


### PR DESCRIPTION
cdxgen license fetching has issues on maven projects atm, see https://github.com/CycloneDX/cdxgen/issues/2058

thus disabling it for now, https://github.com/MediaMarktSaturn/technolinator/issues/860 for tracking