### PR TITLE
revert(deps): downgrade dependency @cyclonedx/cdxgen to v12.1.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 env:
-  CDXGEN_VERSION: '12.2.0'
+  CDXGEN_VERSION: '12.1.5'
   CDXGEN_PLUGINS_VERSION: '1.8.0'
   GRYPE_VERSION: 'v0.111.0'
   SBOMQS_VERSION: 'v2.0.6'


### PR DESCRIPTION
This reverts commit d20ae2fa517b6ad21bfd01683bbe6b891672692b.
And pull request #1004.

Because since this version, the SBom on main couldn't be published
with error
```
Unable to submit the SBOM to the Dependency-Track server
HTTPError: Request failed with status code 400 (Bad Request): PUT ***/api/v1/bom
    at Request.<anonymous> (file:///opt/hostedtoolcache/node/21.7.3/x64/lib/node_modules/@cyclonedx/cdxgen/node_modules/got/dist/source/as-promise/index.js:98:42)
    at Object.onceWrapper (node:events:634:26)
    at Request.emit (node:events:531:35)
    at Request._onResponseBase (file:///opt/hostedtoolcache/node/21.7.3/x64/lib/node_modules/@cyclonedx/cdxgen/node_modules/got/dist/source/core/index.js:779:22)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async Request._onResponse (file:///opt/hostedtoolcache/node/21.7.3/x64/lib/node_modules/@cyclonedx/cdxgen/node_modules/got/dist/source/core/index.js:829:13) {
```

Therefore, revert this version to verify whether there's some bug in this update.
