### PR TITLE
chore(renovate): enable dependency dashboard

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -16,7 +16,7 @@
   "platform": "github",
   "forkProcessing": "disabled",
   "semanticCommits": "enabled",
-  "dependencyDashboard": false,
+  "dependencyDashboard": true,
   "suppressNotifications": [
     "prIgnoreNotification"
   ],


### PR DESCRIPTION
To have an overview of the state of this repository dependencies.

See also: https://docs.renovatebot.com/key-concepts/dashboard/
